### PR TITLE
ci: harden checkout credentials and agent guidance

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -27,7 +27,9 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Select Xcode 26.5
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+## Repository purpose
+
+A macOS CoreMediaIO camera extension packaged in a SwiftUI host app. The extension publishes the bundled `Extension/video.mp4` as a virtual camera named `Gareth Video Cam`.
+
+## Project structure
+
+- `Makefile` - repository verification targets
+- `scripts` - baseline checks and helper scripts
+- `docs` - plans, notes, and generated README assets
+- `GarethVideoCam.xcodeproj` - Xcode project
+- `Extension` - repository source or sample assets
+- `GarethVideoCam` - repository source or sample assets
+
+## Development commands
+
+- Install dependencies: no repository-specific install command is documented.
+- Full baseline: `make check`
+- Local Apple development: `open GarethVideoCam.xcodeproj`
+- If a command above skips because a platform toolchain is missing, verify on a machine with that SDK before claiming platform behavior is tested.
+
+## Coding conventions
+
+- Preserve legacy Xcode project settings and signing assumptions unless the change is explicitly about modernization.
+
+## Testing guidance
+
+- Test-related files detected: `docs/plans/2026-06-08-validate-project-parser-test.md`, `scripts/test_build_unsigned.sh`, `scripts/test_collect_runtime_diagnostics.sh`, `scripts/test_scan_build_log.py`, `scripts/test_validate_project.py`, `scripts/test_verify_build_products.sh`
+- Start with the narrowest relevant test or Make target, then run `make check` before handing off if the change is not documentation-only.
+- Keep README verification notes in sync when commands, fixtures, or supported toolchains change.
+
+## PR / change guidance
+
+- Keep diffs focused on the requested repository and avoid unrelated modernization or formatting churn.
+- Preserve public APIs, sample behavior, file formats, and documented environment variables unless the task explicitly changes them.
+- Update tests, README notes, or docs/plans when behavior, security posture, or validation commands change.
+- Call out skipped platform validation, legacy toolchain assumptions, and any risky files touched in the final summary.
+
+## Safety and gotchas
+
+- No repo-specific secrets are documented; keep local credentials, build outputs, and machine-specific files out of commits.
+
+## Agent workflow
+
+1. Inspect the README, Makefile, manifests, and the files directly related to the request.
+2. Make the smallest source or docs change that satisfies the task; avoid generated, vendored, or local-environment files unless required.
+3. Run the narrowest useful validation first, then `make check` or the documented package/platform gate when available.
+4. If a required SDK, service credential, or external runtime is unavailable, record the skipped command and why.
+5. Summarize changed files, commands run, and remaining risks or follow-up validation.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,9 @@
   reads remain active and stopping on cancelled or invalid reader states. See
   `docs/plans/2026-06-10-reader-status-loop-guard.md`.
 - Pinned checkout and artifact-upload actions by commit and added validator
-  mutation tests that reject floating workflow tags. See
+  mutation tests that reject floating workflow tags. Checkout now disables
+  persisted credentials, and structural tests reject duplicate checkout steps
+  plus missing, duplicate, relocated, or contradictory credential settings. See
   `docs/plans/2026-06-10-pin-ci-actions.md`.
 - Flagged Xcode install-failed banners in the build-log scanner.
 - Rejected path-like unsigned build architecture overrides before resolving

--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ architecture tokens before `xcodebuild` is resolved or build logs are created.
 
 Pushes and pull requests to `main` also run `.github/workflows/macos-build.yml` on GitHub's `macos-26` runner. That workflow records the selected macOS, Xcode, Swift, and macOS SDK evidence, runs `make check`, performs unsigned Debug and Release target builds, verifies the built app products contain the embedded system extension, aligned bundle versions, declared executables, display metadata, product-specific privacy usage strings, bundled runtime diagnostics self-tests, resolved CoreMediaIO extension metadata, and bundled-video metadata, captures the Xcode logs under `.build/Xcode/Logs`, scans any captured `build-*.log` output including partial logs from failed builds, and fails on source warnings, errors, build-failed, archive-failed, analyze-failed, clean-failed, install-failed, and test-failed banners, build or test failure summaries, or nonzero Xcode command failures. Xcode 26.5 currently emits an AppIntents metadata processor notice for targets without AppIntents; CI filters only that known tool notice.
 
-Third-party workflow actions are pinned to reviewed commit SHAs, and validator
-mutation tests reject regressions to floating release tags.
+Third-party workflow actions are pinned to reviewed commit SHAs, checkout does
+not persist workflow credentials, and validator mutation tests reject floating
+or duplicate checkout actions and malformed credential settings.
 See `docs/plans/2026-06-10-pin-ci-actions.md` for the supply-chain guard.
 
 ## Runtime Activation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,7 +55,9 @@ This repository does not use a root package dependency manifest. If dependencies
 
 Build and validation changes should keep `./scripts/check_project.sh`, `.github/workflows/macos-build.yml`, `./scripts/build_unsigned.sh`, `./scripts/verify_build_products.sh`, and `./scripts/scan_build_log.py` aligned so local and CI evidence stay comparable.
 Keep third-party workflow actions pinned to reviewed commit SHAs; update the
-validator and mutation tests with any intentional action upgrade.
+validator and mutation tests with any intentional action upgrade. Checkout must
+keep `persist-credentials: false` in its own `with` mapping so later build steps
+cannot reuse the workflow token through local Git configuration.
 Unsigned-build architecture overrides should remain single architecture tokens
 so local and CI builds do not write ambiguous `ARCHS` values into evidence.
 

--- a/docs/plans/2026-06-10-pin-ci-actions.md
+++ b/docs/plans/2026-06-10-pin-ci-actions.md
@@ -10,10 +10,14 @@ executed with the workflow token.
 
 ## Changes
 
-- Pinned `actions/checkout` v6.0.2 and `actions/upload-artifact` v7.0.1 to their
+- Pinned `actions/checkout` v6.0.3 and `actions/upload-artifact` v7.0.1 to their
   official commit SHAs.
+- Disabled persisted checkout credentials so later build and validation steps
+  cannot reuse the workflow token through the local Git configuration.
 - Updated project validation to require those exact action commits.
-- Added mutation tests that reject regressions to floating action tags.
+- Added dependency-free structural workflow validation and mutation tests that
+  reject floating or duplicate checkout actions plus missing, duplicate,
+  relocated, or contradictory credential settings.
 
 ## Verification
 

--- a/scripts/test_validate_project.py
+++ b/scripts/test_validate_project.py
@@ -1573,6 +1573,84 @@ def test_validator_rejects_floating_checkout_action():
     )
 
 
+def test_validator_rejects_duplicate_checkout_action():
+    assert_validator_rejects_mutation(
+        ".github/workflows/macos-build.yml",
+        """      - name: Select Xcode 26.5
+""",
+        """      - name: Duplicate checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Select Xcode 26.5
+""",
+        "macOS build workflow should contain exactly one checkout action step",
+    )
+
+
+def test_validator_rejects_incorrect_checkout_release_annotation():
+    assert_validator_rejects_mutation(
+        ".github/workflows/macos-build.yml",
+        "# v6.0.3",
+        "# v6.0.2",
+        "macOS build workflow should label the checkout action with its exact release",
+    )
+
+
+def test_validator_rejects_missing_checkout_credential_guard():
+    assert_validator_rejects_mutation(
+        ".github/workflows/macos-build.yml",
+        """        with:
+          persist-credentials: false
+""",
+        "",
+        "macOS build workflow checkout should disable persisted credentials exactly once in the checkout step",
+    )
+
+
+def test_validator_rejects_duplicate_checkout_credential_guard():
+    assert_validator_rejects_mutation(
+        ".github/workflows/macos-build.yml",
+        """        with:
+          persist-credentials: false
+""",
+        """        with:
+          persist-credentials: false
+          persist-credentials: false
+""",
+        "macOS build workflow checkout should disable persisted credentials exactly once in the checkout step",
+    )
+
+
+def test_validator_rejects_relocated_checkout_credential_guard():
+    assert_validator_rejects_mutation(
+        ".github/workflows/macos-build.yml",
+        """env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+""",
+        """env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  persist-credentials: false
+""",
+        "macOS build workflow checkout should disable persisted credentials exactly once in the checkout step",
+    )
+
+
+def test_validator_rejects_contradictory_checkout_credential_guard():
+    assert_validator_rejects_mutation(
+        ".github/workflows/macos-build.yml",
+        """        with:
+          persist-credentials: false
+""",
+        """        with:
+          persist-credentials: false
+          persist-credentials: true
+""",
+        "macOS build workflow checkout should disable persisted credentials exactly once in the checkout step",
+    )
+
+
 def test_validator_rejects_floating_artifact_action():
     assert_validator_rejects_mutation(
         ".github/workflows/macos-build.yml",
@@ -1941,6 +2019,14 @@ def main():
     test_validator_rejects_missing_appintents_ignore_disqualifier()
     test_validator_rejects_missing_appintents_same_line_warning_disqualifier()
     test_validator_rejects_missing_partial_ci_log_scan()
+    test_validator_rejects_floating_checkout_action()
+    test_validator_rejects_duplicate_checkout_action()
+    test_validator_rejects_incorrect_checkout_release_annotation()
+    test_validator_rejects_missing_checkout_credential_guard()
+    test_validator_rejects_duplicate_checkout_credential_guard()
+    test_validator_rejects_relocated_checkout_credential_guard()
+    test_validator_rejects_contradictory_checkout_credential_guard()
+    test_validator_rejects_floating_artifact_action()
     test_validator_rejects_missing_unreadable_build_log_guard()
     test_validator_rejects_root_level_unsigned_build_logs()
     test_validator_rejects_missing_build_product_python_resolver()

--- a/scripts/validate_project.py
+++ b/scripts/validate_project.py
@@ -25,6 +25,87 @@ EXPECTED_EXTENSION_ENTITLEMENT_KEYS = {
     APP_SANDBOX_ENTITLEMENT,
     APP_GROUP_ENTITLEMENT,
 }
+CHECKOUT_ACTION = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"
+CHECKOUT_RELEASE = "v6.0.3"
+
+
+def workflow_steps(workflow_text):
+    lines = workflow_text.splitlines()
+    steps = []
+
+    for header_index, line in enumerate(lines):
+        header_match = re.fullmatch(r"(\s*)steps:\s*", line)
+        if not header_match:
+            continue
+
+        header_indent = len(header_match.group(1))
+        step_starts = []
+        index = header_index + 1
+
+        while index < len(lines):
+            current_line = lines[index]
+            if current_line.strip():
+                current_indent = len(current_line) - len(current_line.lstrip())
+                if current_indent <= header_indent:
+                    break
+                if current_indent == header_indent + 2 and re.match(r"\s*-\s+", current_line):
+                    step_starts.append(index)
+            index += 1
+
+        for position, start in enumerate(step_starts):
+            end = step_starts[position + 1] if position + 1 < len(step_starts) else index
+            steps.append({"start": start, "end": end, "lines": lines[start:end]})
+
+    return steps
+
+
+def workflow_action_references(step):
+    references = []
+
+    for offset, line in enumerate(step["lines"]):
+        match = re.fullmatch(r"\s*(?:-\s*)?uses:\s*([^\s#]+)(?:\s+#\s*(.*?))?\s*", line)
+        if match:
+            references.append({
+                "line": step["start"] + offset,
+                "reference": match.group(1),
+                "annotation": match.group(2) or "",
+                "step": step,
+            })
+
+    return references
+
+
+def workflow_key_occurrences(workflow_text, key):
+    occurrences = []
+    pattern = re.compile(rf"(\s*){re.escape(key)}:\s*([^\s#]+)\s*(?:#.*)?")
+
+    for line_number, line in enumerate(workflow_text.splitlines()):
+        match = pattern.fullmatch(line)
+        if match:
+            occurrences.append({
+                "line": line_number,
+                "indent": len(match.group(1)),
+                "value": match.group(2),
+            })
+
+    return occurrences
+
+
+def workflow_key_is_direct_step_input(step, occurrence):
+    relative_line = occurrence["line"] - step["start"]
+    if relative_line < 0 or relative_line >= len(step["lines"]):
+        return False
+
+    for index in range(relative_line - 1, -1, -1):
+        line = step["lines"][index]
+        if not line.strip():
+            continue
+        indent = len(line) - len(line.lstrip())
+        if indent >= occurrence["indent"]:
+            continue
+        return line.strip() == "with:" and occurrence["indent"] == indent + 2
+
+    return False
 
 
 def load_plist(relative_path):
@@ -1358,11 +1439,37 @@ def main():
             failures)
     if workflow_path.exists():
         workflow_text = workflow_path.read_text()
+        checkout_references = [
+            reference
+            for step in workflow_steps(workflow_text)
+            for reference in workflow_action_references(step)
+            if reference["reference"].startswith("actions/checkout@")
+        ]
+        require(len(checkout_references) == 1,
+                "macOS build workflow should contain exactly one checkout action step",
+                failures)
+        if len(checkout_references) == 1:
+            checkout_reference = checkout_references[0]
+            require(checkout_reference["reference"] == CHECKOUT_ACTION,
+                    "macOS build workflow should pin the Node 24-capable checkout action",
+                    failures)
+            require(checkout_reference["annotation"] == CHECKOUT_RELEASE,
+                    "macOS build workflow should label the checkout action with its exact release",
+                    failures)
+            credential_occurrences = workflow_key_occurrences(workflow_text, "persist-credentials")
+            checkout_credentials = [
+                occurrence
+                for occurrence in credential_occurrences
+                if checkout_reference["step"]["start"] <= occurrence["line"] < checkout_reference["step"]["end"]
+                and workflow_key_is_direct_step_input(checkout_reference["step"], occurrence)
+            ]
+            require(len(credential_occurrences) == 1
+                    and len(checkout_credentials) == 1
+                    and checkout_credentials[0]["value"] == "false",
+                    "macOS build workflow checkout should disable persisted credentials exactly once in the checkout step",
+                    failures)
         require("runs-on: macos-26" in workflow_text,
                 "macOS build workflow should run on the macOS 26 runner",
-                failures)
-        require("actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" in workflow_text,
-                "macOS build workflow should pin the Node 24-capable checkout action",
                 failures)
         require("FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true" in workflow_text,
                 "macOS build workflow should opt JavaScript actions into Node 24",


### PR DESCRIPTION
## Summary

Historical closed pull request: ci: harden checkout credentials and agent guidance

### Original Description

### Summary

Future repository work now has explicit guidance for preserving the virtual-camera sample’s bundle IDs, app groups, entitlements, signing assumptions, video fixture, and validation evidence. The macOS workflow also checks out source without persisting the workflow token, and a dependency-free structural validator rejects duplicate checkout steps or missing, duplicate, relocated, and contradictory credential settings.

The remediation branch is based on current `main`, including the pinned macOS workflow and asset-reader completion guard, rather than the three older draft PRs that contain unrelated or conflicting README and Xcode migrations.

### Validation

- Bash syntax checks for all shell helpers
- Project validator and complete validator mutation suite
- Direct mutations for duplicate checkout, incorrect release annotation, and missing, duplicate, relocated, or contradictory `persist-credentials` settings
- Build-log scanner, unsigned-build helper, runtime-diagnostics, and build-product verifier tests
- `make lint`, `make test`, `make build`, and `make check`, each separately timeout-bounded
- Reader-completion and pinned-checkout regression mutations
- `git diff --check` and staged diff checks
- No generated Python bytecode or cache committed

This Linux host does not provide `xcodebuild`, `xcrun`, Swift, or macOS runtime tools. The prior hosted macOS 26/Xcode 26.5 build passed at `5a56b5c`, including unsigned Debug/Release builds and product verification: https://github.com/garethpaul/GarethMacVirtualCamera/actions/runs/27389176123. A fresh hosted build validates the credential-hardened head.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/gpt--5.4-000000)

## Baseline

The original pull request predates the fleet-standard description contract; repository history and code remain unchanged by this metadata update.

## Improvements

The implementation intent remains the SwiftUI networking, safety, testing, CI, or documentation change described by the title and preserved original description.

## Validation

No code was rerun solely for this metadata normalization. Fresh exact-master local and hosted validation is recorded separately in the engineering-bar tracker.

## Risk

This description-only normalization changes no source, commit, branch, credential, project setting, dependency, or runtime behavior.

## Follow-Ups

No follow-up is required for this metadata-only update; Apple-platform and live-provider limitations remain tracked in the exact-head evidence.
