### PR TITLE
docs: record reader cleanup verification

### DIFF
--- a/docs/plans/2026-06-12-stale-reader-cancellation.md
+++ b/docs/plans/2026-06-12-stale-reader-cancellation.md
@@ -54,3 +54,24 @@ unnecessary file and decoder work and makes stream teardown ownership clear.
 - Mutations removing cancellation from the task-cancelled, released-source, or
   stale-completion path must fail.
 - Hosted macOS/Xcode unsigned Debug and Release builds must pass.
+
+## Work Completed
+
+- Cancelled prepared readers when task cancellation is observed after reader
+  creation, when the device source has been released, and when a queued
+  completion no longer matches the active stream generation.
+- Preserved active reader installation, loop restart, timer ownership, and
+  multi-client stream accounting.
+- Added validator mutations for all three abandoned-reader cleanup paths and
+  updated the maintenance documentation.
+
+## Verification Completed
+
+- `./scripts/test_validate_project.py`, `./scripts/check_project.sh`, all four
+  Make gates, and `git diff --check` passed locally. The validator suite
+  rejected removal of each of the three required `cancelReading()` calls.
+- Pull-request run `27393152277` passed at commit
+  `d23f0c0a60abc46250feef451d21f3093d8e93f1`, including the local validation
+  baseline, Xcode 26.5 unsigned build, product verification, and build-log scan.
+- Post-merge push run `27393226357` and CodeQL run `27402321140` passed at
+  default-branch merge commit `26b6799887daff57c3df00c56da9b8eb16e3d665`.

--- a/scripts/test_validate_project.py
+++ b/scripts/test_validate_project.py
@@ -605,6 +605,24 @@ def test_validator_rejects_missing_released_source_reader_cleanup():
     )
 
 
+def test_validator_rejects_stale_reader_plan_status_regression():
+    assert_validator_rejects_mutation(
+        "docs/plans/2026-06-12-stale-reader-cancellation.md",
+        "status: completed",
+        "status: planned",
+        "stale reader cancellation plan should record completed status and actual verification",
+    )
+
+
+def test_validator_rejects_stale_reader_plan_evidence_regression():
+    assert_validator_rejects_mutation(
+        "docs/plans/2026-06-12-stale-reader-cancellation.md",
+        "Pull-request run `27393152277`",
+        "Pull-request run `00000000000`",
+        "stale reader cancellation plan should record completed status and actual verification",
+    )
+
+
 def test_validator_rejects_missing_video_dimension_unwrap_guard():
     assert_validator_rejects_mutation(
         "Extension/ExtensionProvider.swift",
@@ -1997,6 +2015,8 @@ def main():
     test_validator_rejects_missing_cancelled_preparation_reader_cleanup()
     test_validator_rejects_missing_stale_completion_reader_cleanup()
     test_validator_rejects_missing_released_source_reader_cleanup()
+    test_validator_rejects_stale_reader_plan_status_regression()
+    test_validator_rejects_stale_reader_plan_evidence_regression()
     test_validator_rejects_missing_video_dimension_unwrap_guard()
     test_validator_rejects_missing_finite_video_dimension_guard()
     test_validator_rejects_missing_non_finite_video_frame_rate_guard()

--- a/scripts/validate_project.py
+++ b/scripts/validate_project.py
@@ -442,6 +442,8 @@ def main():
     changes_text = changes_path.read_text() if changes_path.exists() else ""
     plan_path = ROOT / "docs/plans/2026-06-08-make-check-baseline.md"
     plan_text = plan_path.read_text() if plan_path.exists() else ""
+    stale_reader_plan_path = ROOT / "docs/plans/2026-06-12-stale-reader-cancellation.md"
+    stale_reader_plan_text = stale_reader_plan_path.read_text() if stale_reader_plan_path.exists() else ""
     docs_plan_paths = sorted((ROOT / "docs/plans").glob("*.md"))
     check_project_path = ROOT / "scripts/check_project.sh"
     check_project_source = check_project_path.read_text()
@@ -502,6 +504,23 @@ def main():
         require("make check" in docs_plan_text,
                 f"{docs_plan_path.relative_to(ROOT)} should document make check verification",
                 failures)
+    stale_reader_statuses = re.findall(r"^status: .+$", stale_reader_plan_text, flags=re.MULTILINE)
+    stale_reader_sections = stale_reader_plan_text.split("## Verification Completed\n", 1)
+    stale_reader_verification = stale_reader_sections[1] if len(stale_reader_sections) == 2 else ""
+    stale_reader_required_evidence = (
+        "`./scripts/test_validate_project.py`, `./scripts/check_project.sh`, all four",
+        "Pull-request run `27393152277`",
+        "push run `27393226357`",
+        "CodeQL run `27402321140`",
+        "three required `cancelReading()` calls",
+    )
+    require(stale_reader_statuses == ["status: completed"]
+            and all(item in stale_reader_verification for item in stale_reader_required_evidence)
+            and re.search(r"\b(?:pending|todo|tbd)\b", stale_reader_verification, re.IGNORECASE) is None
+            and "test_validator_rejects_stale_reader_plan_status_regression" in validate_project_test_source
+            and "test_validator_rejects_stale_reader_plan_evidence_regression" in validate_project_test_source,
+            "stale reader cancellation plan should record completed status and actual verification",
+            failures)
     require(changes_path.exists() and "make lint" in changes_text and "make test" in changes_text and "make build" in changes_text and "make check" in changes_text and "docs/plans/" in changes_text,
             "CHANGES should record the Makefile validation gate baseline",
             failures)


### PR DESCRIPTION
## Summary

- record the completed stale-reader cancellation work with exact local and hosted evidence
- require section-specific completed verification in the canonical Python validator
- add end-to-end regression tests for stale plan status and falsified hosted evidence

## Baseline

The pre-change constraints and motivation are captured in the Summary and existing supporting sections.

## Improvements

The implemented changes are captured in the Summary and existing supporting sections.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 ./scripts/test_validate_project.py`
- `./scripts/validate_project.py`
- `make lint`
- `make test`
- `make build`
- `make check`
- `git diff --check`

The full validator suite continues to reject removal of cancellation from the task-cancelled, released-source, and stale-completion paths.

## Risk

Documentation and validation only. Camera extension runtime behavior and Xcode project configuration are unchanged.

## Follow-Ups

No additional follow-up is introduced by this description-only normalization; existing monitoring and remaining-work notes remain authoritative.
