### PR TITLE
test: make project checks location independent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Made project verification independent of the caller's working directory by
+  rooting both the Make entry point and the maintained check script.
 - Extended the canonical macOS workflow to pushes and pull requests on every
   branch so stacked changes receive the maintained Xcode build gate.
 - Kept rejected camera samples from committing loop offset, presentation-time,

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: build check lint test
 
+ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 lint test build: check
 
 check:
-	./scripts/check_project.sh
+	@"$(ROOT)/scripts/check_project.sh"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ The `lint`, `test`, and `build` targets currently delegate to `make check` so
 the same validator, mutation tests, script checks, and whitespace checks run
 through every local gate entry point.
 
+Use the absolute Makefile path to run the same gates from another working
+directory. Both Make and the check script resolve the repository root before
+running the maintained relative commands.
+
 The check script runs project metadata validation, validator mutation tests for recent runtime-readiness guardrails, build-log scanner tests, unsigned build script tests, runtime diagnostics tests, build-product verifier tests, shell syntax checks, and whitespace checks. The build-product verifier checks bundle identifiers, aligned bundle versions, declared executables, display metadata, product-specific privacy usage strings, bundled runtime diagnostics self-tests, resolved CoreMediaIO extension metadata, and bundled-video resource metadata. The validator also checks exact host and extension entitlement keys, shared app-group values, Xcode entitlement file bindings, the Makefile gate targets, the bundled `Extension/video.mp4` for parseable dimensions, frame rate, and positive video duration, and the extension's decoded pixel-buffer and host-clock sample-timing guards. Rejected samples do not commit loop offset, presentation-time, or host-timebase state. Completed-reader loop handling and explicit cancellation of prepared readers abandoned during asynchronous startup are also enforced, so resource and stream-format regressions fail before runtime activation.
 
 The build-product verifier prefers `/usr/bin/python3` for plist and bundled-video metadata parsing and accepts `PYTHON3_BIN` when CI or a local runner needs an explicit interpreter path.

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -1,7 +1,7 @@
 ---
 title: Location-Independent Project Verification
 date: 2026-06-13
-status: planned
+status: completed
 execution: code
 ---
 
@@ -50,8 +50,26 @@ whitespace, unsigned-build, product-verification, and hosted macOS baseline.
 
 ## Work Completed
 
-Pending implementation.
+- Rooted the Make entry point from the loaded Makefile and invoked the
+  maintained checker through its absolute repository path.
+- Made `scripts/check_project.sh` enter its own repository root before running
+  the existing relative validation commands.
+- Added validator and mutation-test contracts for behavior, completed evidence,
+  and synchronized guidance without touching application or project files.
 
 ## Verification Completed
 
-Pending implementation and validation. Run `make check` before completion.
+- `./scripts/validate_project.py`, `./scripts/test_validate_project.py`, and
+  `./scripts/check_project.sh` passed.
+- All four Make gates (`make lint`, `make test`, `make build`, and `make check`)
+  passed at repository root and from /tmp through the absolute Makefile path.
+- The caller-relative Makefile mutation failed.
+- The missing check-script root mutation failed.
+- The plan-status mutation failed.
+- The plan-evidence mutation failed.
+- The documentation mutation failed.
+- Python and shell syntax, plist/project/scheme parsing, `git diff --check`,
+  exact intended-path review, added-line secret/signing inspection, and
+  generated-artifact inspection passed.
+- Signed extension activation and live virtual-camera output were unavailable
+  on this Linux host and are not claimed.

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -1,0 +1,57 @@
+---
+title: Location-Independent Project Verification
+date: 2026-06-13
+status: planned
+execution: code
+---
+
+## Context
+
+The maintained project gate succeeds from the checkout but fails when the
+absolute Makefile is invoked from another working directory. Both the Make
+recipe and `scripts/check_project.sh` resolve repository paths through the
+caller's current directory.
+
+## Priority
+
+This is the next isolated reliability gap because CI and local automation
+should be able to load the repository Makefile without first changing
+directories. The fix must preserve the complete validator, fixture, shell,
+whitespace, unsigned-build, product-verification, and hosted macOS baseline.
+
+## Requirements
+
+- Derive the repository root from `MAKEFILE_LIST` in `Makefile`.
+- Invoke `scripts/check_project.sh` through the rooted Make path.
+- Make `scripts/check_project.sh` enter its own repository root before running
+  the existing relative commands.
+- Add validator and mutation-test contracts for the rooted Makefile, rooted
+  check script, completed plan, external-run evidence, and synchronized
+  guidance.
+- Keep Swift, Xcode project, entitlements, signing, workflow, fixtures, and
+  bundled media unchanged.
+
+## Verification Plan
+
+- Run focused validator tests, direct project validation, all shell fixture
+  suites, and all four Make gates at repository root.
+- Run all four Make gates from /tmp through the absolute Makefile path.
+- Reject caller-relative Makefile, missing check-script root, plan-status,
+  plan-evidence, and documentation mutations.
+- Run Python and shell syntax, plist/project/scheme parsing, `git diff --check`,
+  exact-path review, secret/signing inspection, and generated-artifact checks.
+
+## Non-Goals
+
+- Changing camera sample processing, runtime activation, host UI, dependencies,
+  Xcode project settings, entitlements, signing, or hosted workflow policy.
+- Claiming signed extension activation or live virtual-camera output on this
+  Linux host.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and validation. Run `make check` before completion.

--- a/scripts/check_project.sh
+++ b/scripts/check_project.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
 ./scripts/validate_project.py
 PYTHONDONTWRITEBYTECODE=1 ./scripts/test_validate_project.py
 ./scripts/test_scan_build_log.py

--- a/scripts/test_validate_project.py
+++ b/scripts/test_validate_project.py
@@ -698,6 +698,53 @@ def test_validator_rejects_missing_pull_request_validation():
     )
 
 
+def test_validator_rejects_caller_relative_makefile():
+    assert_validator_rejects_mutation(
+        "Makefile",
+        "ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))",
+        "ROOT := $(CURDIR)",
+        "Makefile should expose lint, test, build, and check validation entry points",
+    )
+
+
+def test_validator_rejects_missing_check_project_root():
+    assert_validator_rejects_mutation(
+        "scripts/check_project.sh",
+        '''ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+''',
+        "",
+        "check_project should enter its repository root before running relative commands",
+    )
+
+
+def test_validator_rejects_location_independent_make_plan_status_regression():
+    assert_validator_rejects_mutation(
+        "docs/plans/2026-06-13-location-independent-make.md",
+        "status: completed",
+        "status: planned",
+        "location-independent Make plan should record completed status and actual verification",
+    )
+
+
+def test_validator_rejects_location_independent_make_plan_evidence_regression():
+    assert_validator_rejects_mutation(
+        "docs/plans/2026-06-13-location-independent-make.md",
+        "caller-relative Makefile mutation failed",
+        "caller-relative Makefile mutation inspected",
+        "location-independent Make plan should record completed status and actual verification",
+    )
+
+
+def test_validator_rejects_location_independent_make_documentation_regression():
+    assert_validator_rejects_mutation(
+        "README.md",
+        "absolute Makefile path",
+        "loaded build file path",
+        "README and CHANGES should document location-independent project verification",
+    )
+
+
 def test_validator_rejects_missing_video_dimension_unwrap_guard():
     assert_validator_rejects_mutation(
         "Extension/ExtensionProvider.swift",
@@ -2133,6 +2180,11 @@ def main():
     test_validator_rejects_main_only_push_validation()
     test_validator_rejects_main_only_pull_request_validation()
     test_validator_rejects_missing_pull_request_validation()
+    test_validator_rejects_caller_relative_makefile()
+    test_validator_rejects_missing_check_project_root()
+    test_validator_rejects_location_independent_make_plan_status_regression()
+    test_validator_rejects_location_independent_make_plan_evidence_regression()
+    test_validator_rejects_location_independent_make_documentation_regression()
     test_validator_rejects_missing_video_dimension_unwrap_guard()
     test_validator_rejects_missing_finite_video_dimension_guard()
     test_validator_rejects_missing_non_finite_video_frame_rate_guard()

--- a/scripts/validate_project.py
+++ b/scripts/validate_project.py
@@ -466,6 +466,8 @@ def main():
     transactional_timing_plan_text = transactional_timing_plan_path.read_text() if transactional_timing_plan_path.exists() else ""
     all_branch_ci_plan_path = ROOT / "docs/plans/2026-06-13-all-branch-hosted-validation.md"
     all_branch_ci_plan_text = all_branch_ci_plan_path.read_text() if all_branch_ci_plan_path.exists() else ""
+    location_independent_make_plan_path = ROOT / "docs/plans/2026-06-13-location-independent-make.md"
+    location_independent_make_plan_text = location_independent_make_plan_path.read_text() if location_independent_make_plan_path.exists() else ""
     docs_plan_paths = sorted((ROOT / "docs/plans").glob("*.md"))
     check_project_path = ROOT / "scripts/check_project.sh"
     check_project_source = check_project_path.read_text()
@@ -509,8 +511,13 @@ def main():
     require(makefile_path.exists()
             and ".PHONY: build check lint test" in makefile_text
             and "lint test build: check" in makefile_text
-            and "./scripts/check_project.sh" in makefile_text,
+            and 'ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))' in makefile_text
+            and '"$(ROOT)/scripts/check_project.sh"' in makefile_text,
             "Makefile should expose lint, test, build, and check validation entry points",
+            failures)
+    require('ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"' in check_project_source
+            and 'cd "$ROOT"' in check_project_source,
+            "check_project should enter its repository root before running relative commands",
             failures)
     require(plan_path.exists() and "status: completed" in plan_text and "make check" in plan_text and "./scripts/check_project.sh" in plan_text,
             "docs/plans should record the completed make-check baseline plan",
@@ -582,6 +589,35 @@ def main():
             and "test_validator_rejects_main_only_pull_request_validation" in validate_project_test_source
             and "test_validator_rejects_missing_pull_request_validation" in validate_project_test_source,
             "all-branch hosted validation plan should record completed status and actual verification",
+            failures)
+    location_independent_make_statuses = re.findall(r"^status: .+$", location_independent_make_plan_text, flags=re.MULTILINE)
+    location_independent_make_sections = location_independent_make_plan_text.split("## Verification Completed\n", 1)
+    location_independent_make_verification = location_independent_make_sections[1] if len(location_independent_make_sections) == 2 else ""
+    location_independent_make_required_evidence = (
+        "`./scripts/test_validate_project.py`",
+        "`./scripts/validate_project.py`",
+        "`./scripts/check_project.sh`",
+        "All four Make gates",
+        "from /tmp",
+        "caller-relative Makefile mutation failed",
+        "missing check-script root mutation failed",
+        "plan-status mutation failed",
+        "plan-evidence mutation failed",
+        "documentation mutation failed",
+    )
+    require(location_independent_make_statuses == ["status: completed"]
+            and all(item in location_independent_make_verification for item in location_independent_make_required_evidence)
+            and re.search(r"\b(?:pending|todo|tbd|not run)\b", location_independent_make_verification, re.IGNORECASE) is None
+            and "test_validator_rejects_caller_relative_makefile" in validate_project_test_source
+            and "test_validator_rejects_missing_check_project_root" in validate_project_test_source
+            and "test_validator_rejects_location_independent_make_plan_status_regression" in validate_project_test_source
+            and "test_validator_rejects_location_independent_make_plan_evidence_regression" in validate_project_test_source
+            and "test_validator_rejects_location_independent_make_documentation_regression" in validate_project_test_source,
+            "location-independent Make plan should record completed status and actual verification",
+            failures)
+    require("absolute Makefile path" in readme_text
+            and "Made project verification independent" in changes_text,
+            "README and CHANGES should document location-independent project verification",
             failures)
     require(changes_path.exists() and "make lint" in changes_text and "make test" in changes_text and "make build" in changes_text and "make check" in changes_text and "docs/plans/" in changes_text,
             "CHANGES should record the Makefile validation gate baseline",


### PR DESCRIPTION
## Summary

The complete GarethMacVirtualCamera verification baseline now runs from any caller working directory. Loading the repository's absolute Makefile no longer fails because Make or the check script looks for project files under the caller's directory.

## Baseline

All project checks passed from the checkout, but `make -f /absolute/path/to/Makefile check` failed from `/tmp` with `./scripts/check_project.sh: Command not found`.

## Improvements

Make now resolves the loaded Makefile's directory, and `scripts/check_project.sh` enters its own repository root before running the existing relative commands. The project validator and five mutation tests enforce the rooted entry points, completed plan evidence, and synchronized guidance without changing Swift, Xcode project, entitlements, signing, media, or workflow policy.

## Validation

- `scripts/validate_project.py`, the complete validator mutation suite, and `scripts/check_project.sh` passed.
- `make check`, `make lint`, `make test`, and `make build` passed at repository root and from `/tmp` through the absolute Makefile path.
- Caller-relative Makefile, missing script-root, plan-status, plan-evidence, and documentation mutations were rejected.
- Python/shell syntax, plist/project/scheme inspection, `git diff --check`, exact intended-path review, added-line secret/signing inspection, and generated-artifact inspection passed.
- Plan-aware correctness, testing, maintainability, security, and project-standards review found no actionable findings.

## Risk

The change is limited to validation entry points, contracts, tests, and documentation. Signed system-extension activation and live virtual-camera output remain unavailable on this Linux host and are not claimed.

## Follow-Ups

The stacked base PR #8 must remain available and merge first. Runtime activation still requires an appropriately provisioned macOS host.

## Post-Deploy Monitoring & Validation

No additional production monitoring is required because this repository has no deployed service. The owner should confirm the exact-head push and pull-request `Validate and Build` jobs remain successful; any failure to locate repository validation files is the rollback trigger.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
