### PR TITLE
fix: protect Make root from overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build check lint test
 
-ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 lint test build: check
 

--- a/scripts/test_validate_project.py
+++ b/scripts/test_validate_project.py
@@ -701,9 +701,18 @@ def test_validator_rejects_missing_pull_request_validation():
 def test_validator_rejects_caller_relative_makefile():
     assert_validator_rejects_mutation(
         "Makefile",
-        "ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))",
+        "override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))",
         "ROOT := $(CURDIR)",
-        "Makefile should expose lint, test, build, and check validation entry points",
+        "Makefile should protect its root and expose lint, test, build, and check validation entry points",
+    )
+
+
+def test_validator_rejects_overrideable_makefile_root():
+    assert_validator_rejects_mutation(
+        "Makefile",
+        "override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))",
+        "ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))",
+        "Makefile should protect its root and expose lint, test, build, and check validation entry points",
     )
 
 
@@ -2106,7 +2115,7 @@ def test_validator_rejects_missing_make_gate_aliases():
         "Makefile",
         "\nlint test build: check\n",
         "\n",
-        "Makefile should expose lint, test, build, and check validation entry points",
+        "Makefile should protect its root and expose lint, test, build, and check validation entry points",
     )
 
 

--- a/scripts/validate_project.py
+++ b/scripts/validate_project.py
@@ -514,9 +514,9 @@ def main():
     require(makefile_path.exists()
             and ".PHONY: build check lint test" in makefile_text
             and "lint test build: check" in makefile_text
-            and 'ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))' in makefile_text
+            and 'override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))' in makefile_text
             and '"$(ROOT)/scripts/check_project.sh"' in makefile_text,
-            "Makefile should expose lint, test, build, and check validation entry points",
+            "Makefile should protect its root and expose lint, test, build, and check validation entry points",
             failures)
     require('ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"' in check_project_source
             and 'cd "$ROOT"' in check_project_source,


### PR DESCRIPTION
## Summary

Historical closed pull request: fix: protect Make root from overrides

### Original Description

### Summary

- make the repository-derived Make root authoritative against command-line overrides
- update the project validator to require the protected assignment
- add a direct regression mutation for an overrideable root

### Validation

- project validator and validator regression suite
- build-log scanner, unsigned-build, runtime-diagnostics, and build-product verifier tests
- all external aliases with `ROOT=/nonexistent` remain anchored to the exact checkout
- checksum-verified gitleaks 8.30.1, shell syntax, diff check, and git object integrity

The local environment has no `swift` command, so the required hosted macOS workflow is the authoritative full `swift test` and Xcode build evidence. No credentials were loaded.

## Baseline

The original pull request predates the fleet-standard description contract; repository history and code remain unchanged by this metadata update.

## Improvements

The implementation intent remains the SwiftUI networking, safety, testing, CI, or documentation change described by the title and preserved original description.

## Validation

No code was rerun solely for this metadata normalization. Fresh exact-master local and hosted validation is recorded separately in the engineering-bar tracker.

## Risk

This description-only normalization changes no source, commit, branch, credential, project setting, dependency, or runtime behavior.

## Follow-Ups

No follow-up is required for this metadata-only update; Apple-platform and live-provider limitations remain tracked in the exact-head evidence.
