### PR TITLE
fix: replace str.removesuffix with Python 3.8 compatible slicing

### DIFF
--- a/scripts/test_validate_project.py
+++ b/scripts/test_validate_project.py
@@ -1770,12 +1770,12 @@ def test_validator_rejects_untrimmed_icon_size_metadata():
 def test_validator_rejects_permissive_icon_integer_metadata():
     assert_validator_rejects_mutation(
         "scripts/validate_project.py",
-        """    scale_digits = scale_value.removesuffix("x")
+        """    scale_digits = scale_value[:-1]
     if not re.fullmatch(r"[0-9]+", size_parts[0]) or not re.fullmatch(r"[0-9]+", size_parts[1]) or not re.fullmatch(r"[0-9]+", scale_digits):
         return None
 
 """,
-        """    scale_digits = scale_value.removesuffix("x")
+        """    scale_digits = scale_value[:-1]
 """,
         "app icon validator should reject malformed icon catalog size metadata without raising",
     )

--- a/scripts/validate_project.py
+++ b/scripts/validate_project.py
@@ -322,7 +322,7 @@ def expected_icon_pixel_size(image):
     if not scale_value.endswith("x"):
         return None
 
-    scale_digits = scale_value.removesuffix("x")
+    scale_digits = scale_value[:-1]
     if not re.fullmatch(r"[0-9]+", size_parts[0]) or not re.fullmatch(r"[0-9]+", size_parts[1]) or not re.fullmatch(r"[0-9]+", scale_digits):
         return None
 


### PR DESCRIPTION
## Summary

Replace `str.removesuffix()` (Python 3.9+) with equivalent `str[:-1]` slicing to restore Python 3.8 compatibility.

## Why

`str.removesuffix()` was added in Python 3.9, but the environment (and CI runner) uses Python 3.8.10. This caused `make check` to fail with:

```
AttributeError: 'str' object has no attribute 'removesuffix'
```

## Changes

- `scripts/validate_project.py`: replace `scale_value.removesuffix("x")` with `scale_value[:-1]` (the `endswith("x")` guard runs immediately before, so this is safe)
- `scripts/test_validate_project.py`: update mutation test embedded source snippets to match

## Verification

```
python3 --version  # 3.8.10
./scripts/validate_project.py  # PASSED
PYTHONDONTWRITEBYTECODE=1 ./scripts/test_validate_project.py  # PASSED
```

## Risk

Low. Single-character change in a path already guarded by `endswith("x")`.

## Notes

The `swift test` step in `check_project.sh` requires macOS/Xcode and is expected to fail on Linux.